### PR TITLE
Fix "resize not defined" error

### DIFF
--- a/touchscreen/__init__.py
+++ b/touchscreen/__init__.py
@@ -155,7 +155,7 @@ def assure_plugged_in():
         mw.reviewer.revHtml = custom
 
 def resize_js():
-    execute_js("setTimeout(resize, 101);");
+    execute_js("if (typeof resize === 'function') { setTimeout(resize, 101); }");
     
 def clear_blackboard():
     assure_plugged_in()
@@ -163,7 +163,7 @@ def clear_blackboard():
     if ts_state_on:
         execute_js("clear_canvas();");
         # is qFade the reason for having to wait?
-        execute_js("setTimeout(resize, 101);");
+        execute_js("if (typeof resize === 'function') { setTimeout(resize, 101); }");
 
 def ts_onload():
     """


### PR DESCRIPTION
I encountered a JavaScript error on the backside of the card when "enable touchscreen mode" was turned off. The error was:

```
Uncaught ReferenceError: resize is not defined
    at <anonymous>:1:12
```
**Cause**:

The code was attempting to call the `resize` function without checking if it was defined. This was particularly the case when the "enable touchscreen mode" was disabled, as the `resize` function was not defined in that context.

**Solution**:

I added a conditional check before calling the `resize` function to ensure it is defined. This prevents trying to call an undefined function and resolves the error.