### PR TITLE
Feature: Initial visibility config, default pen selection, and tag-based auto-toggle

### DIFF
--- a/AnkiDraw/__init__.py
+++ b/AnkiDraw/__init__.py
@@ -361,10 +361,14 @@ body {
 </style>"""
 
 def blackboard_js():
+    config = mw.addonManager.getConfig(__name__)
+    start_vis = str(config.get('start_visible', False)).lower()
+    start_pen = str(config.get('default_pen_index', 1))
+
     return u"""
 <script>
 // Set from python qt ui
-var visible = """ + ts_default_VISIBILITY + """;
+var visible = """ + start_vis + """;
 var perfectFreehand = """ + ts_default_PerfFreehand +""";
 var pressureSensitivity = """ + str(ts_pressure_sensitivity).lower() + """;
 var small_canvas = """ +  str(ts_default_small_canvas).lower() + """;
@@ -389,7 +393,7 @@ var fontFamily = """ + "\'" + str(ts_font_family) + "\'" + """;
 var fontSize = """ + str(ts_font_size) + """;
 var fontBold = """ + str(ts_font_bold).lower() + """;
 var fontItalic = """ + str(ts_font_italic).lower() + """;
-var activePenIndex = 0;
+var activePenIndex = """ + start_pen + """;
 var convertDotStrokes = true
 
 function getPenColorAndWidthByIndex(index){
@@ -461,6 +465,18 @@ var ts_switch_pen3_button_path = document.querySelector('#ts_switch_pen3_button 
 var ts_switch_pen4_button_path = document.querySelector('#ts_switch_pen4_button > svg > path');
 
 // Arrays to save point values from strokes
+if (!visible) {
+    canvas.style.display = 'none';
+    secondary_canvas.style.display = 'none';
+    
+    if (ts_visibility_button) {
+        ts_visibility_button.className = '';
+    }
+    
+    if (optionBar) {
+        optionBar.className = 'touch_disable';
+    }
+}
 var stroke_cache = [ ];
 var lineHistory = [ ] // contains history of currentAction Items, defined below
 var redoStack = [ ]
@@ -684,10 +700,9 @@ function switch_small_canvas()
 function switch_visibility()
 {
 	stop_drawing();
-    if (visible)
-    {
+    if (!visible) {
         canvas.style.display='none';
-        secondary_canvas.style.display=canvas.style.display;
+        secondary_canvas.style.display='none';
         ts_visibility_button.className = '';
         optionBar.className = 'touch_disable';
     }

--- a/AnkiDraw/__init__.py
+++ b/AnkiDraw/__init__.py
@@ -396,6 +396,26 @@ var fontItalic = """ + str(ts_font_italic).lower() + """;
 var activePenIndex = """ + start_pen + """;
 var convertDotStrokes = true
 
+function forceShowCanvas() {
+    if (visible === false) { // Only change if it's currently false
+        visible = true;
+        canvas.style.display='block';
+        secondary_canvas.style.display='block';
+        if (ts_visibility_button) ts_visibility_button.className = 'active';
+        if (optionBar) optionBar.className = '';
+    }
+}
+
+function forceHideCanvas() {
+    if (visible === true) { // Only change if it's currently true
+        visible = false;
+        canvas.style.display='none';
+        secondary_canvas.style.display='none';
+        if (ts_visibility_button) ts_visibility_button.className = '';
+        if (optionBar) optionBar.className = 'touch_disable';
+    }
+}
+
 function getPenColorAndWidthByIndex(index){
     switch (index) {
         case 0:
@@ -2320,3 +2340,32 @@ def ts_onload():
     ts_setup_menu()
 
 ts_onload()
+
+from aqt.qt import QTimer
+
+def apply_visibility_logic():
+    """
+    Checks for the 'draw' tag and directly calls the
+    appropriate JavaScript function to show or hide the canvas.
+    """
+    if not mw.reviewer.card or not mw.reviewer.web:
+        return
+
+    target_tag = "draw" 
+
+    note_tags = [t.lower() for t in mw.reviewer.card.note().tags]
+    should_show = target_tag.lower() in note_tags
+
+    if should_show:
+        mw.reviewer.web.eval("forceShowCanvas();")
+    else:
+        mw.reviewer.web.eval("forceHideCanvas();")
+
+def check_for_draw_tag_wrapper(*args):
+    """
+    Wrapper to handle hook arguments and add a small delay
+    to ensure the card's web content is fully loaded.
+    """
+    QTimer.singleShot(100, apply_visibility_logic)
+
+addHook("showQuestion", check_for_draw_tag_wrapper)

--- a/AnkiDraw/config.json
+++ b/AnkiDraw/config.json
@@ -1,4 +1,4 @@
 {
-    "start_visible": false,
-    "default_pen_index": 1
+    "start_visible": true,
+    "default_pen_index": 0
 }

--- a/AnkiDraw/config.json
+++ b/AnkiDraw/config.json
@@ -1,0 +1,4 @@
+{
+    "start_visible": false,
+    "default_pen_index": 1
+}

--- a/AnkiDraw/config.md
+++ b/AnkiDraw/config.md
@@ -1,0 +1,7 @@
+# AnkiDraw Configuration
+
+**start_visible**  
+If enabled, the drawing canvas opens automatically when reviewing a deck.
+
+**default_pen_index**  
+Choose which pen is selected when the card loads.


### PR DESCRIPTION
This pull request introduces new configuration options and logic to better control the initial state of the drawing canvas.

**Changes:**

*   **Configuration:**
    start_visible: Boolean option to determine if the canvas should be open by default when reviewing.
    default_pen_index: Integer option to set the active pen when the card loads.
*   **Tag-based Logic:**
    Added a check for the tag "draw" on the current note.
    If the "draw" tag is present, the canvas is forced to show regardless of the default configuration.
    If the tag is absent, it respects the specific hide/show logic defined in the configuration.
*   **JavaScript & Hooks:**
    Implemented forceShowCanvas() and forceHideCanvas() functions to programmatically control display states.
    Added a Python hook to showQuestion (with a slight QTimer delay) to evaluate tags and trigger the Javascript state changes.

**Known Issues:**

*   There is currently a bug regarding the UI synchronization when starting a deck. The visibility toggle button may require a double-click to register the first interaction/state change properly.